### PR TITLE
Add 'on Exception' to catch(e)

### DIFF
--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -420,7 +420,7 @@ module.exports = class IBMi {
             }
           }
           
-        } catch (e) {
+        } on Exception catch (e) {
           console.log(e);
         }
 


### PR DESCRIPTION
Pokémon exception handling caused the try...catch at line 401 to encounter an unexpected error when `/QOpenSys/pkgs/bin/` directory path does not exist. The command `ls -p /QOpenSys/pkgs/bin/` returns code 2. As a result, the next path for remoteApps `/usr/bin/` is never checked for installed applications. This caused a false-negative for autoConvertIFSccsid in situations where it should have been usable.


### Changes

Replaces a catch clause with a catch on Exception clause.

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/halcyon-tech/vscode-ibmi/blob/master/CONTRIBUTING.md)
* [ ] **for feature PRs**: PR only includes one feature enhancement.
